### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -12,7 +12,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@1340ff58ac2ad7bfba86fa531784bbd575d4b9b0 # proj-v1
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to align with the xmidt-org Ideal State as described in issue #113.

## Changes Made

- **ci.yml**: Added top-level `permissions` block with `pull-requests: read`, `contents: write`, and `packages: write`
- **auto-releaser.yml**: Created new workflow file with SHA-pinned reference to `xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41)
- **approve-dependabot.yml**: Renamed from `dependabot-approver.yml` and updated to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41) with SHA pinning
- **proj-xmidt-team.yml**: Added top-level `permissions` block with `contents: read`, `issues: write`, and `pull-requests: write`, and pinned workflow reference to commit SHA `1340ff58ac2ad7bfba86fa531784bbd575d4b9b0` (proj-v1)

Resolves #113